### PR TITLE
Sgratzl/migrate provenance graph

### DIFF
--- a/src/CLUEGraphManager.ts
+++ b/src/CLUEGraphManager.ts
@@ -96,7 +96,7 @@ export default class CLUEGraphManager {
   migrateGraph(graph: ProvenanceGraph, extras: any = {}): Promise<ProvenanceGraph> {
     return this.manager.migrateRemote(graph, extras).then((newGraph) => {
       return (graph.desc.local ? this.manager.delete(graph.desc) : Promise.resolve(true)).then(() => {
-        CLUEGraphManager.setGraphInUrl(newGraph.desc.id); //just update the reference
+        hash.setProp('clue_graph', newGraph.desc.id); //just update the reference
         return newGraph;
       });
     });

--- a/src/CLUEGraphManager.ts
+++ b/src/CLUEGraphManager.ts
@@ -94,8 +94,9 @@ export default class CLUEGraphManager {
   }
 
   migrateGraph(graph: ProvenanceGraph, extras: any = {}): Promise<ProvenanceGraph> {
+    const old = graph.desc;
     return this.manager.migrateRemote(graph, extras).then((newGraph) => {
-      return (graph.desc.local ? this.manager.delete(graph.desc) : Promise.resolve(true)).then(() => {
+      return (old.local ? this.manager.delete(old) : Promise.resolve(true)).then(() => {
         hash.setProp('clue_graph', newGraph.desc.id); //just update the reference
         return newGraph;
       });

--- a/src/CLUEGraphManager.ts
+++ b/src/CLUEGraphManager.ts
@@ -93,6 +93,15 @@ export default class CLUEGraphManager {
     });
   }
 
+  migrateGraph(graph: ProvenanceGraph, extras: any = {}): Promise<ProvenanceGraph> {
+    return this.manager.migrateRemote(graph, extras).then((newGraph) => {
+      return (graph.desc.local ? this.manager.delete(graph.desc) : Promise.resolve(true)).then(() => {
+        CLUEGraphManager.setGraphInUrl(newGraph.desc.id); //just update the reference
+        return newGraph;
+      });
+    });
+  }
+
   editGraphMetaData(graph: IProvenanceGraphDataDescription, extras: any = {}) {
     return this.manager.edit(graph, extras);
   }


### PR DESCRIPTION
option to migrate a temporary provenance graph to a persistent one without replaying. see https://github.com/Caleydo/ordino/issues/118