### PR TITLE
Add extension point `phoveaProvenanceGraph`

### DIFF
--- a/src/ACLUEWrapper.ts
+++ b/src/ACLUEWrapper.ts
@@ -13,7 +13,7 @@ import ProvenanceGraph from 'phovea_core/src/provenance/ProvenanceGraph';
 import SlideNode from 'phovea_core/src/provenance/SlideNode';
 import {resolveImmediately} from 'phovea_core/src';
 import {list, IPluginDesc} from 'phovea_core/src/plugin';
-import {PHOVEA_PROVENANCE_GRAPH} from './extensions';
+import {EP_PHOVEA_CLUE_PROVENANCE_GRAPH} from './extensions';
 
 const TEMPLATE = `<div class="box">
   <header>
@@ -75,7 +75,7 @@ export abstract class ACLUEWrapper extends EventHandler {
 
     this.graph.then((graph) => {
       // load registered extensions and pass the ready graph to extension
-      list(PHOVEA_PROVENANCE_GRAPH).map((desc: IPluginDesc) => {
+      list(EP_PHOVEA_CLUE_PROVENANCE_GRAPH).map((desc: IPluginDesc) => {
         desc.load().then((plugin) => plugin.factory(graph));
       });
 

--- a/src/ACLUEWrapper.ts
+++ b/src/ACLUEWrapper.ts
@@ -12,6 +12,8 @@ import StateNode from 'phovea_core/src/provenance/StateNode';
 import ProvenanceGraph from 'phovea_core/src/provenance/ProvenanceGraph';
 import SlideNode from 'phovea_core/src/provenance/SlideNode';
 import {resolveImmediately} from 'phovea_core/src';
+import {list, IPluginDesc} from 'phovea_core/src/plugin';
+import {PHOVEA_PROVENANCE_GRAPH} from './extensions';
 
 const TEMPLATE = `<div class="box">
   <header>
@@ -72,6 +74,11 @@ export abstract class ACLUEWrapper extends EventHandler {
     this.provVis = provVis;
 
     this.graph.then((graph) => {
+      // load registered extensions and pass the ready graph to extension
+      list(PHOVEA_PROVENANCE_GRAPH).map((desc: IPluginDesc) => {
+        desc.load().then((plugin) => plugin.factory(graph));
+      });
+
       graph.on('run_chain', () => {
         if (this.urlTracking === EUrlTracking.ENABLE) {
           this.urlTracking = EUrlTracking.DISABLE_JUMPING;

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -1,0 +1,5 @@
+/**
+ * Provide the loaded provenance graph
+ */
+export const PHOVEA_PROVENANCE_GRAPH = 'phoveaProvenanceGraph';
+

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -1,5 +1,7 @@
 /**
- * Provide the loaded provenance graph
+ * Provides the loaded provenance graph
+ *
+ * @factoryParam {ProvenanceGraph} provenanceGraph The loaded provenance graph
  */
-export const PHOVEA_PROVENANCE_GRAPH = 'phoveaProvenanceGraph';
+export const EP_PHOVEA_CLUE_PROVENANCE_GRAPH = 'epPhoveaClueProvenanceGraph';
 


### PR DESCRIPTION
Closes #143

## Changes

* Add a new extension point `phoveaProvenanceGraph`, which provides the already loaded provenance graph

## Usage

_plugin_repo/phovea.js_
```js
module.exports = function (registry) {
  registry.push('epPhoveaClueProvenanceGraph', 'yourExtensionName', function () {
    return import('./src/tracker');
  }, {
    'factory': 'trackProvenance'
  });
};
```

**OR**

_plugin_repo/src/phovea.ts_
```ts
import {IRegistry} from 'phovea_core/src/plugin';
import {EP_PHOVEA_CLUE_PROVENANCE_GRAPH} from 'phovea_clue/src/extensions';

export default function (registry: IRegistry) {
  registry.push(EP_PHOVEA_CLUE_PROVENANCE_GRAPH, 'yourExtensionName', () => System.import('./tracker'), {
    factory: 'trackProvenance'
  });
}
```

_plugin_repo/src/tracker.ts_
```ts
import {ProvenanceGraph} from 'phovea_core/src/provenance';

/**
 * Provenance graph extension point
 * @param graph ProvenanceGraph
 */
export function trackProvenance(graph: ProvenanceGraph) {
  console.log('provenance graph', graph);
}
```
