### PR TITLE
Fix phovea_security_flask package URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "marked": "0.3.9",
     "phovea_ui": "github:phovea/phovea_core#develop",
     "phovea_core": "github:phovea/phovea_core#develop",
-    "phovea_security_flask": "github:phovea/phovea_core#develop"
+    "phovea_security_flask": "github:phovea/phovea_security_flask#develop"
   },
   "devDependencies": {
     "@types/jasmine": "2.5.47",


### PR DESCRIPTION
Wrong repo (phovea_core) is referenced in package.json