### PR TITLE
Fix jquery typings for `.find()`

### DIFF
--- a/src/menu/ProvenanceGraphMenu.ts
+++ b/src/menu/ProvenanceGraphMenu.ts
@@ -187,14 +187,14 @@ export default class ProvenanceGraphMenu {
                 </div>
             </div>
         </div>`);
-        $elem.find('button.btn-danger').on('click', () => {
+        $elem.find<HTMLElement>('button.btn-danger').on('click', () => {
           areyousure(i18n.t('phovea:clue.provenanceMenu.areYouSureToDelete', {name: graph.name})).then((deleteIt) => {
             if (deleteIt) {
               manager.delete(graph);
             }
           });
         });
-        $elem.find('button.btn-primary').on('click', function () {
+        $elem.find<HTMLElement>('button.btn-primary').on('click', function () {
           const isSelect = this.dataset.action === 'select';
           manager.loadOrClone(graph, isSelect);
           return false;
@@ -203,10 +203,10 @@ export default class ProvenanceGraphMenu {
       }
     }).parent().on({
       mouseenter() {
-        (<any>$(this).find('a')).popover('show');
+        (<any>$(this).find<HTMLElement>('a')).popover('show');
       },
       mouseleave() {
-        (<any>$(this).find('a')).popover('hide');
+        (<any>$(this).find<HTMLElement>('a')).popover('hide');
       }
     });
   }

--- a/src/provvis.ts
+++ b/src/provvis.ts
@@ -594,11 +594,11 @@ export class LayoutedProvVis extends vis.AVisInstance implements vis.IVisInstanc
     const jp = $($p.node());
     const that = this;
     //must use bootstrap since they are manually triggered
-    jp.find('form.toolbar input, .legend input').on('change', function() {
+    jp.find<HTMLElement>('form.toolbar input, .legend input').on('change', function() {
       const inputElement = <HTMLInputElement>this;
       if (inputElement.type === 'text') {
         that.highlight.tags = inputElement.value.split(' ');
-        jp.find('button[data-toggle="dropdown"]').toggleClass('active', that.highlight.tags.length > 0);
+        jp.find<HTMLElement>('button[data-toggle="dropdown"]').toggleClass('active', that.highlight.tags.length > 0);
       } else {
         that.highlight[inputElement.name][inputElement.value] = inputElement.checked;
       }
@@ -606,15 +606,15 @@ export class LayoutedProvVis extends vis.AVisInstance implements vis.IVisInstanc
     });
     //initialize bootstrap
     lazyBootstrap().then(($$) => {
-      $$($p.node()).find('*[data-toggle="buttons"],.btn[data-toggle="button"]').button();
+      $$($p.node()).find<HTMLElement>('*[data-toggle="buttons"],.btn[data-toggle="button"]').button();
     });
 
-    jp.find('.btn-filter').on('click', () => {
-      jp.find('form.toolbar').toggle('fast');
+    jp.find<HTMLElement>('.btn-filter').on('click', () => {
+      jp.find<HTMLElement>('form.toolbar').toggle('fast');
       return false;
     });
 
-    jp.find('.btn-collapse').on('click', (evt) => {
+    jp.find<HTMLElement>('.btn-collapse').on('click', (evt) => {
       evt.preventDefault();
       const collapsed = !$p.classed('collapsed');
       this.toggleBinding(!collapsed);
@@ -729,23 +729,23 @@ export class LayoutedProvVis extends vis.AVisInstance implements vis.IVisInstanc
 
 
     //just for the entered ones
-    //(<any>$($states_enter[0][0]).find('> span.icon')).popover(StateRepr.popover)
+    //(<any>$($states_enter[0][0]).find<HTMLElement>('> span.icon')).popover(StateRepr.popover)
     //  .parent().on({
     //    mouseenter: function () {
-    //      var $icon = $(this).find('> span.icon');
+    //      var $icon = $(this).find<HTMLElement>('> span.icon');
     //      $icon.addClass('popping');
     //      $icon.data('popup', setTimeout(function () {
     //        (<any>$icon).popover('show');
     //      }, 200));
     //    },
     //    mouseleave: function () {
-    //      var $icon = $(this).find('> span.icon');
+    //      var $icon = $(this).find<HTMLElement>('> span.icon');
     //      const id = +$icon.data('popoup');
     //      clearTimeout(id);
     //      $icon.removeData('popup');
     //      const d:StateRepr = d3.select(this).datum();
     //      if (d && $icon.has('textarea')) {
-    //        const val = $(this).find('textarea').val();
+    //        const val = $(this).find<HTMLElement>('textarea').val();
     //        d.s.setAttr('tags', extractTags(val));
     //        d.s.setAttr('note', val);
     //      }

--- a/src/storyvis.ts
+++ b/src/storyvis.ts
@@ -291,9 +291,9 @@ export class VerticalStoryVis extends vis.AVisInstance implements vis.IVisInstan
       return false;
     });
     const jp = $($node.node());
-    (<any>jp.find('.dropdown-toggle')).dropdown();
-    jp.find('h2 i.fa-plus-circle').on('click', () => {
-      jp.find('form.toolbar').toggle('fast');
+    (<any>jp.find<HTMLElement>('.dropdown-toggle')).dropdown();
+    jp.find<HTMLElement>('h2 i.fa-plus-circle').on('click', () => {
+      jp.find<HTMLElement>('form.toolbar').toggle('fast');
     });
 
     {
@@ -318,7 +318,7 @@ export class VerticalStoryVis extends vis.AVisInstance implements vis.IVisInstan
 
 
     if (this.data.getSlideChains().length === 0) {
-      jp.find('form.toolbar').toggle('fast');
+      jp.find<HTMLElement>('form.toolbar').toggle('fast');
     }
 
     return $node;


### PR DESCRIPTION
Closes #189

### Summary

* Typings of the `.find()` have been changed in PR https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44051
* Change typing from `HTMLElement` to `Element`
* `Element` does not contain the `dataset` property
* Fixed by manually typecasting all methods `.find<HTMLElement>()`

Follow-up discussion on the jQuery typing isuse can be found here https://github.com/DefinitelyTyped/DefinitelyTyped/issues/44268.